### PR TITLE
Add shared memory volume mounts for GPU images

### DIFF
--- a/applications/gpu/template-gpu-jupyterlab.yml
+++ b/applications/gpu/template-gpu-jupyterlab.yml
@@ -145,6 +145,8 @@ objects:
               - name: workdir
                 mountPath: /workspace/notebooks
                 # subPath: ${STORAGE_FOLDER}
+              - name: dshm
+                mountPath: /dev/shm                
             env:
               - name: JUPYTER_TOKEN
                 value: ${JUPYTER_TOKEN}
@@ -157,6 +159,9 @@ objects:
           - name: workdir
             persistentVolumeClaim:
               claimName: ${APPLICATION_NAME}
+          - name: dshm
+            emptyDir:
+              medium: Memory                   
     selector:
       app: ${APPLICATION_NAME}
       deploymentconfig: ${APPLICATION_NAME}

--- a/applications/gpu/template-gpu-vscode.yml
+++ b/applications/gpu/template-gpu-vscode.yml
@@ -146,6 +146,8 @@ objects:
               - name: workdir
                 mountPath: /root
                 # subPath: ${STORAGE_FOLDER}
+              - name: dshm
+                mountPath: /dev/shm
             env:
               - name: PASSWORD
                 value: ${PASSWORD}
@@ -158,6 +160,9 @@ objects:
           - name: workdir
             persistentVolumeClaim:
               claimName: ${APPLICATION_NAME}
+          - name: dshm
+            emptyDir:
+              medium: Memory     
     selector:
       app: ${APPLICATION_NAME}
       deploymentconfig: ${APPLICATION_NAME}


### PR DESCRIPTION
Before sending a pull request make sure the DSRI documentation website still work as expected with the new changes properly integrated. Check the README to run the website in a development environment: https://github.com/MaastrichtU-IDS/dsri-documentation#run-for-development

## Motivation
Shared Memory is essential for multiprocessing and should be a default on GPU containers

## Changes added
This PR integrates default volume mounts for shared memory as mentioned here: https://access.redhat.com/documentation/en-us/openshift_container_platform/3.10/html/developer_guide/dev-guide-shared-memory


List the changes added to the documentation here
No changes made to docs
