### PR TITLE
Add annotation and runtimeClassName for large volume issue (https://g…

### DIFF
--- a/applications/templates/restricted/template-jupyterlab-restricted.yml
+++ b/applications/templates/restricted/template-jupyterlab-restricted.yml
@@ -113,11 +113,13 @@ objects:
     template:
       metadata:
         annotations:
+          io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel: 'true'
           alpha.image.policy.openshift.io/resolve-names: "*"
         labels:
           app: "${APPLICATION_NAME}"
           deploymentconfig: "${APPLICATION_NAME}"
       spec:
+        runtimeClassName: selinux
         serviceAccountName: anyuid
         # nodeSelector:
         #   dsri.unimaas.nl/cpu: 'true'

--- a/applications/templates/restricted/template-rstudio-shiny-restricted.yml
+++ b/applications/templates/restricted/template-rstudio-shiny-restricted.yml
@@ -231,9 +231,12 @@ objects:
     replicas: 1
     template:
       metadata:
+        annotations:
+          io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel: 'true'
         labels:
           app: rstudio
       spec:
+        runtimeClassName: selinux
         #nodeSelector:
         #  dsri.unimaas.nl/cpu: 'true'
         volumes:

--- a/applications/templates/restricted/template-vscode-restricted.yml
+++ b/applications/templates/restricted/template-vscode-restricted.yml
@@ -111,10 +111,13 @@ objects:
         deploymentconfig: ${NAME}
       template:
         metadata:
+          annotations:
+            io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel: 'true'
           labels:
             app: ${NAME}
             deploymentconfig: ${NAME}
         spec:
+          runtimeClassName: selinux
           #nodeSelector:
            # dsri.unimaas.nl/cpu: 'true'
           # hostname: ${CONTAINER_HOSTNAME}

--- a/applications/templates/template-cellprofiler.yml
+++ b/applications/templates/template-cellprofiler.yml
@@ -109,10 +109,13 @@ objects:
       deploymentconfig: "${APPLICATION_NAME}"
     template:
       metadata:
+        annotations:
+          io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel: 'true'
         labels:
           app: "${APPLICATION_NAME}"
           deploymentconfig: "${APPLICATION_NAME}"
       spec:
+        runtimeClassName: selinux
         serviceAccountName: anyuid
         #nodeSelector:
         # dsri.unimaas.nl/cpu: 'true'

--- a/applications/templates/template-custom-workspace.yml
+++ b/applications/templates/template-custom-workspace.yml
@@ -139,10 +139,13 @@ objects:
       deploymentconfig: "${APPLICATION_NAME}"
     template:
       metadata:
+        annotations:
+          io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel: 'true'
         labels:
           app: "${APPLICATION_NAME}"
           deploymentconfig: "${APPLICATION_NAME}"
       spec:
+        runtimeClassName: selinux
         serviceAccountName: "anyuid"
         # nodeSelector:
         #   dsri.unimaas.nl/cpu: 'true'

--- a/applications/templates/template-filebrowser.yml
+++ b/applications/templates/template-filebrowser.yml
@@ -86,10 +86,13 @@ objects:
       deploymentconfig: "${APPLICATION_NAME}"
     template:
       metadata:
+        annotations:
+          io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel: 'true'
         labels:
           app: "${APPLICATION_NAME}"
           deploymentconfig: "${APPLICATION_NAME}"
       spec:
+        runtimeClassName: selinux
         serviceAccountName: anyuid
         volumes:
         - name: data

--- a/applications/templates/template-jupyterlab-existing-pvc.yml
+++ b/applications/templates/template-jupyterlab-existing-pvc.yml
@@ -176,10 +176,13 @@ objects:
       deploymentconfig: "${APPLICATION_NAME}"
     template:
       metadata:
+        annotations:
+          io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel: 'true'
         labels:
           app: "${APPLICATION_NAME}"
           deploymentconfig: "${APPLICATION_NAME}"
       spec:
+        runtimeClassname: selinux
         serviceAccountName: "anyuid"
         # nodeSelector:
         #   dsri.unimaas.nl/cpu: 'true'

--- a/applications/templates/template-jupyterlab-root.yml
+++ b/applications/templates/template-jupyterlab-root.yml
@@ -168,10 +168,13 @@ objects:
       deploymentconfig: "${APPLICATION_NAME}"
     template:
       metadata:
+        annotations:
+          io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel: 'true'
         labels:
           app: "${APPLICATION_NAME}"
           deploymentconfig: "${APPLICATION_NAME}"
       spec:
+        runtimeClassName: selinux
         serviceAccountName: "anyuid"
         # nodeSelector:
         #   dsri.unimaas.nl/cpu: 'true'

--- a/applications/templates/template-ontotext-graphdb.yml
+++ b/applications/templates/template-ontotext-graphdb.yml
@@ -104,10 +104,13 @@ objects:
       deploymentconfig: "${APPLICATION_NAME}"
     template:
       metadata:
+        annotations:
+          io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel: 'true'
         labels:
           app: "${APPLICATION_NAME}"
           deploymentconfig: "${APPLICATION_NAME}"
       spec:
+        runtimeClassName: selinux
         serviceAccountName: anyuid
         # nodeSelector:
         #   dsri.unimaas.nl/cpu: 'true'

--- a/applications/templates/template-rstudio-root.yml
+++ b/applications/templates/template-rstudio-root.yml
@@ -121,11 +121,13 @@ objects:
     template:
       metadata:
         annotations:
+          io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel: 'true'
           alpha.image.policy.openshift.io/resolve-names: "*"
         labels:
           app: "${APPLICATION_NAME}"
           deploymentconfig: "${APPLICATION_NAME}"
       spec:
+        runtimeClassName: selinux
         serviceAccountName: anyuid
         #nodeSelector:
         #  dsri.unimaas.nl/cpu: 'true'

--- a/applications/templates/template-trinityrnaseq.yml
+++ b/applications/templates/template-trinityrnaseq.yml
@@ -101,10 +101,13 @@ objects:
       deploymentconfig: "${APPLICATION_NAME}"
     template:
       metadata:
+        annotations:
+          io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel: 'true'
         labels:
           app: "${APPLICATION_NAME}"
           deploymentconfig: "${APPLICATION_NAME}"
       spec:
+        runtimeClassName: selinux
         serviceAccountName: anyuid
         #nodeSelector:
         # dsri.unimaas.nl/cpu: 'true'

--- a/applications/templates/template-ubuntu-root.yml
+++ b/applications/templates/template-ubuntu-root.yml
@@ -104,10 +104,13 @@ objects:
       deploymentconfig: "${APPLICATION_NAME}"
     template:
       metadata:
+        annotations:
+          io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel: 'true'
         labels:
           app: "${APPLICATION_NAME}"
           deploymentconfig: "${APPLICATION_NAME}"
       spec:
+        runtimeClassName: selinux
         serviceAccountName: anyuid
         #nodeSelector:
         # dsri.unimaas.nl/cpu: 'true'

--- a/applications/templates/template-ubuntu-vnc.yml
+++ b/applications/templates/template-ubuntu-vnc.yml
@@ -128,10 +128,13 @@ objects:
       deploymentconfig: "${APPLICATION_NAME}"
     template:
       metadata:
+        annotations:
+          io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel: 'true'
         labels:
           app: "${APPLICATION_NAME}"
           deploymentconfig: "${APPLICATION_NAME}"
       spec:
+        runtimeClassName: selinux
         serviceAccountName: anyuid
         #nodeSelector:
         # dsri.unimaas.nl/cpu: 'true'

--- a/applications/templates/template-virtuoso.yml
+++ b/applications/templates/template-virtuoso.yml
@@ -134,10 +134,13 @@ objects:
       deploymentconfig: "${APPLICATION_NAME}"
     template:
       metadata:
+        annotations:
+          io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel: 'true'
         labels:
           app: "${APPLICATION_NAME}"
           deploymentconfig: "${APPLICATION_NAME}"
       spec:
+        runtimeClassName: selinux
         serviceAccountName: anyuid
         # nodeSelector:
         #   dsri.unimaas.nl/cpu: 'true'

--- a/applications/templates/template-vscode-root.yml
+++ b/applications/templates/template-vscode-root.yml
@@ -116,10 +116,13 @@ objects:
       deploymentconfig: "${APPLICATION_NAME}"
     template:
       metadata:
+        annotations:
+          io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel: 'true'
         labels:
           app: "${APPLICATION_NAME}"
           deploymentconfig: "${APPLICATION_NAME}"
       spec:
+        runtimeClassName: selinux
         serviceAccountName: anyuid
         #nodeSelector:
         #  dsri.unimaas.nl/cpu: 'true'


### PR DESCRIPTION
…ithub.com/minio/minio/discussions/14854)

Before sending a pull request make sure the DSRI documentation website still work as expected with the new changes properly integrated. Check the README to run the website in a development environment: https://github.com/MaastrichtU-IDS/dsri-documentation#run-for-development

## Motivation

Added a annotation and runtimeClassName to the templates.
This makes sure that pods mount large PVC's will skip relabeling of all files inside this volume. This makes sure that CRI-O (2 minutes by default) will not timeout when SElinux labels on the top level are labeled correctly.

Found in: [https://github.com/minio/minio/discussions/14854](url)

## Changes added

List the changes added to the documentation here

```yaml
        annotations:
          io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel: 'true'
...
        runtimeClassName: selinux
