### PR TITLE
Fixed openconnect command

### DIFF
--- a/website/docs/access-dsri.md
+++ b/website/docs/access-dsri.md
@@ -18,7 +18,7 @@ You need to be connected to the UM network to access the DSRI.
 
 ```bash
 sudo apt install openconnect
-sudo openconnect -u YOUR.USER --authgroup 01-Employees vpn.maastrichtuniversity.nl
+sudo openconnect --useragent "AnyConnect" --no-external-auth -u YOUR.USER --authgroup=01 vpn.maastrichtuniversity.nl
 ```
 
 **🍎 On MacOS and Windows**: download and install the **Maastricht University VPN** client available at **[vpn.maastrichtuniversity.nl](https://vpn.maastrichtuniversity.nl/)**

--- a/website/docs/guide-vpn.md
+++ b/website/docs/guide-vpn.md
@@ -76,7 +76,7 @@ Provide your UM username and password. (**employee number** at Maastricht Univer
 
   ```bash
   sudo apt install openconnect
-  sudo openconnect -u YOUR.USER --authgroup 01-Employees --useragent=AnyConnect vpn.maastrichtuniversity.nl
+  sudo openconnect --useragent "AnyConnect" --no-external-auth -u YOUR.USER --authgroup=01 vpn.maastrichtuniversity.nl
   ```
 
   > Provide your UM password when prompted.


### PR DESCRIPTION
Fixed openconnect command. Made it compatible with the VPN-setup changes of Feb 2025.

## Motivation

The openconnect command in the docs is not working with the latest VPN configuration by UM that was introduced in February 2025.

## Changes added

Updated the openconnect command in two pages.

