### PR TITLE
Change 'image:{APPLICATION_NAME}:latest' to use APPLICATION_IMAGE in OpenShift custom templates [RCS-588]

### DIFF
--- a/applications/templates/template-cellprofiler.yml
+++ b/applications/templates/template-cellprofiler.yml
@@ -115,7 +115,7 @@ objects:
             claimName: "${APPLICATION_NAME}"
         containers:
         - name: cellprofiler-container
-          image: ${APPLICATION_NAME}:latest
+          image: ${APPLICATION_IMAGE}
           imagePullPolicy: IfNotPresent
           command: [ "tail", "-f", "/dev/null"]
           ports:

--- a/applications/templates/template-custom-workspace.yml
+++ b/applications/templates/template-custom-workspace.yml
@@ -125,7 +125,7 @@ objects:
         serviceAccountName: "anyuid"
         containers:
         - name: custom-app
-          image: "${APPLICATION_NAME}:latest"
+          image: "${APPLICATION_IMAGE}"
           imagePullPolicy: IfNotPresent
           ports:
           - containerPort: 8888

--- a/applications/templates/template-filebrowser.yml
+++ b/applications/templates/template-filebrowser.yml
@@ -36,6 +36,11 @@ parameters:
   description: Provide the password as a hash (default value is browsemeplease) to login with admin in the filebrowser
   value: $$2a$$10$$1q1DVy.Cz3e5566.UPJT8eeexDspJ4sI8qZR6TfyHvA/7NH0beKY.
   required: true
+- name: APPLICATION_IMAGE
+  displayName: Application image
+  description: Filebrowser image.
+  value: ghcr.io/maastrichtu-ids/filebrowser:v2.11.0
+  required: true
 - name: STORAGE_NAME
   displayName: Storage name
   description: Name of the Persistent Volume Claim that will be exposed by the filebrowser.
@@ -59,7 +64,7 @@ objects:
     - name: latest
       from:
         kind: DockerImage
-        name: ghcr.io/maastrichtu-ids/filebrowser:v2.11.0
+        name: ${APPLICATION_IMAGE}
       importPolicy:
         scheduled: false
     lookupPolicy:
@@ -95,7 +100,7 @@ objects:
             claimName: "${STORAGE_NAME}"
         containers:
         - name: filebrowser-container
-          image: ${APPLICATION_NAME}:latest
+          image: ${APPLICATION_IMAGE}
           imagePullPolicy: IfNotPresent
           args: ["--password", "${APPLICATION_PASSWORD}"]
           ports:


### PR DESCRIPTION
Before sending a pull request make sure the DSRI documentation website still work as expected with the new changes properly integrated. Check the README to run the website in a development environment: https://github.com/MaastrichtU-IDS/dsri-documentation#run-for-development

## Motivation

Shortly describe what motivated those changes

## Changes added

List the changes added to the documentation here

