### PR TITLE
Updated download URL for oc cli in DSRI docs [RCS-961]

### DIFF
--- a/website/docs/openshift-install.md
+++ b/website/docs/openshift-install.md
@@ -18,7 +18,7 @@ The `oc` CLI enables to perform operations on your applications deployed on the 
 Download the `oc` and `kubectl` Command Line Interface clients:
 
 ```shell
-wget https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz && tar xvf oc.tar.gz
+wget https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz && tar xvf openshift-client-linux.tar.gz
 sudo mv oc kubectl /usr/local/bin/
 ```
 
@@ -32,7 +32,7 @@ brew install openshift-cli
 
 Or manually download the program and add it to your path:
 
-1. Download https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/macosx/oc.tar.gz
+1. Download https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-mac.tar.gz
 
 2. Unzip the archive
 
@@ -47,7 +47,7 @@ Or manually download the program and add it to your path:
 ### On Windows
 
 1. Create a folder for OpenShift in Program Files: `C:\Program Files (x86)\OpenShift`
-2. Click [here](https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/windows/oc.zip) to download the `oc` tool `.zip` file, and move it to `C:\Program Files (x86)\OpenShift`.
+2. Click [here](https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-windows.zip) to download the `oc` tool `.zip` file, and move it to `C:\Program Files (x86)\OpenShift`.
 3. Extract the `.zip` file.
 4. Next set the system **PATH** environment variables for the directory containing the `oc.exe` file, which now resides in your newly created **OpenShift** folder inside of `C:\Program Files (x86)\OpenShift`
    1. Open the Control Panel, and click on **System**

--- a/website/docs/openshift-install.md
+++ b/website/docs/openshift-install.md
@@ -51,7 +51,7 @@ Or manually download the program and add it to your path:
 3. Extract the `.zip` file.
 4. Next set the system **PATH** environment variables for the directory containing the `oc.exe` file, which now resides in your newly created **OpenShift** folder inside of `C:\Program Files (x86)\OpenShift`
    1. Open the Control Panel, and click on **System**
-   2. Click on **Advance system settings** on the left or open the **Advance** tab of *System Properties.* 
+   2. Click on **Advanced system settings** on the left or open the **Advanced** tab of *System Properties.* 
    3. Click the button labeled **Environment Variables...** at the bottom. 
    4. Look for the option **Path** in either the **User variables** section (for the current user) or the **System variables** section (for all users on the system).
 
@@ -69,7 +69,7 @@ See the [official documentation to install the client](https://docs.okd.io/lates
 
 :::
 
-## Login in the terminal with `oc`
+## Log in the terminal with `oc`
 
 To use the `oc` Command Line Interface, you will need to authenticate to the [DSRI](https://console-openshift-console.apps.dsri2.unimaas.nl/console) in your terminal:
 


### PR DESCRIPTION
Before sending a pull request make sure the DSRI documentation website still work as expected with the new changes properly integrated. Check the README to run the website in a development environment: https://github.com/MaastrichtU-IDS/dsri-documentation#run-for-development

## Motivation

Shortly describe what motivated those changes

## Changes added

List the changes added to the documentation here

