### PR TITLE
Re-added /dev/shm mount with sizeLimit to GPU templates [RCS-992]

### DIFF
--- a/applications/templates/template-jupyterlab-gpu-pytorch.yml
+++ b/applications/templates/template-jupyterlab-gpu-pytorch.yml
@@ -208,8 +208,14 @@ objects:
           volumeMounts:
           - mountPath: "/workspace/persistent"
             name: data
+          - mountPath: "/dev/shm"
+            name: dshm
         serviceAccountName: anyuid
         volumes:
         - name: data
           persistentVolumeClaim:
             claimName: "${APPLICATION_NAME}"
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 8Gi

--- a/applications/templates/template-jupyterlab-gpu-tensorflow.yml
+++ b/applications/templates/template-jupyterlab-gpu-tensorflow.yml
@@ -208,8 +208,14 @@ objects:
           volumeMounts:
           - mountPath: "/workspace/persistent"
             name: data
+          - mountPath: "/dev/shm"
+            name: dshm
         serviceAccountName: anyuid
         volumes:
         - name: data
           persistentVolumeClaim:
             claimName: "${APPLICATION_NAME}"
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 8Gi

--- a/applications/templates/template-vscode-gpu-pytorch.yml
+++ b/applications/templates/template-vscode-gpu-pytorch.yml
@@ -142,6 +142,10 @@ objects:
             - name: data 
               persistentVolumeClaim:
                 claimName: "${APPLICATION_NAME}"
+            - name: dshm
+              emptyDir:
+                medium: Memory
+                sizeLimit: 8Gi
           containers:
             - name: "${APPLICATION_NAME}" 
               image: "${APPLICATION_IMAGE}" 
@@ -153,6 +157,8 @@ objects:
               volumeMounts:
                 - name: data 
                   mountPath: "/root/persistent" 
+                - name: dshm
+                  mountPath: "/dev/shm"
               env:
                 - name: PASSWORD
                   valueFrom:

--- a/applications/templates/template-vscode-gpu-tensorflow.yml
+++ b/applications/templates/template-vscode-gpu-tensorflow.yml
@@ -142,6 +142,10 @@ objects:
             - name: data 
               persistentVolumeClaim:
                 claimName: "${APPLICATION_NAME}"
+            - name: dshm
+              emptyDir:
+                medium: Memory
+                sizeLimit: 8Gi
           containers:
             - name: "${APPLICATION_NAME}" 
               image: "${APPLICATION_IMAGE}" 
@@ -153,6 +157,8 @@ objects:
               volumeMounts:
                 - name: data 
                   mountPath: "/root/persistent" 
+                - name: dshm
+                  mountPath: "/dev/shm"
               env:
                 - name: PASSWORD
                   valueFrom:


### PR DESCRIPTION
Re-added /dev/shm mount with sizeLimit to GPU templates:
template-jupyterlab-gpu-pytorch.yml
template-jupyterlab-gpu-tensorflow.yml
template-vscode-gpu-pytorch.yml
template-vscode-gpu-tensorflow.yml