### PR TITLE
Updated image registry references to new cluster [RCS-1004]

### DIFF
--- a/applications/templates/on-demand/template-jupyterlab-ants.yaml
+++ b/applications/templates/on-demand/template-jupyterlab-ants.yaml
@@ -31,7 +31,7 @@ parameters:
   - name: APPLICATION_IMAGE
     displayName: ANTs Docker Image
     description: Optimized ANTs 2.6.4 image with JupyterLab.
-    value: default-route-openshift-image-registry.apps.dsri2.unimaas.nl/openshift/ants:2.6.4
+    value: default-route-openshift-image-registry.apps.dsri.unimaas.nl/openshift/ants:2.6.4
     required: true
   - name: STORAGE_SIZE
     displayName: Storage Size

--- a/applications/templates/on-demand/template-jupyterlab-fsl.yaml
+++ b/applications/templates/on-demand/template-jupyterlab-fsl.yaml
@@ -35,7 +35,7 @@ parameters:
   - name: APPLICATION_IMAGE
     displayName: FSL Docker Image
     description: The Docker image for the FSL workspace. Defaults to the FSL 6.0.7 image with JupyterLab pre-installed.
-    value: default-route-openshift-image-registry.apps.dsri2.unimaas.nl/openshift/fsl:6.0.7
+    value: default-route-openshift-image-registry.apps.dsri.unimaas.nl/openshift/fsl:6.0.7
     required: true
   - name: STORAGE_SIZE
     displayName: Storage Size

--- a/applications/templates/on-demand/template-ubuntu-vnc-fmri.yaml
+++ b/applications/templates/on-demand/template-ubuntu-vnc-fmri.yaml
@@ -43,7 +43,7 @@ parameters:
   - name: APPLICATION_IMAGE
     displayName: Docker Image
     description: The optimized integrated fMRI image.
-    value: default-route-openshift-image-registry.apps.dsri2.unimaas.nl/openshift/ubuntu-vnc-fmri:latest
+    value: default-route-openshift-image-registry.apps.dsri.unimaas.nl/openshift/ubuntu-vnc-fmri:latest
     required: true
 
 objects:


### PR DESCRIPTION
Before sending a pull request make sure the DSRI documentation website still work as expected with the new changes properly integrated. Check the README to run the website in a development environment: https://github.com/MaastrichtU-IDS/dsri-documentation#run-for-development

## Motivation

Shortly describe what motivated those changes

## Changes added

List the changes added to the documentation here

